### PR TITLE
External links target blank example

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ This can be used for several things in a build process. Some examples:
 * [Remove whitespace](https://github.com/trygve-lie/gulp-dom/tree/master/examples/remove-whitespace) in the document in a safe way.
 * [Replace script / css references](https://github.com/trygve-lie/gulp-dom/tree/master/examples/replace-script-tags) with a new reference (to ex a minified version).
 * [Web scraping.](https://github.com/trygve-lie/gulp-dom/tree/master/examples/web-scrape) Take a document from a URL and transform it or extract parts of it during build.
+* [Make external links target _blank](https://github.com/trygve-lie/gulp-dom/tree/master/examples/external-links-target-blank)
 
 
 

--- a/examples/external-links-target-blank/gulpfile.js
+++ b/examples/external-links-target-blank/gulpfile.js
@@ -1,0 +1,24 @@
+/* jshint node: true, strict: true */
+
+"use strict";
+
+var gulp     = require('gulp'),
+    dom      = require('../../');
+
+// Gulp task which will make external links target _blank
+
+gulp.task('external-links-target-blank', function() {
+  return gulp.src('src/example.html')
+    .pipe(dom(function() {
+      var links = this.querySelectorAll('a');
+      for (var i = 0; i < links.length; i++) {
+          if (links[i].getAttribute('href').match(/^https?:\/\//)) {
+                links[i].setAttribute('target', '_blank');
+          }                                                                                              
+      }
+      return this;
+    }))
+    .pipe(gulp.dest('./build'));
+});
+
+gulp.task('default', ['external-links-target-blank']);

--- a/examples/external-links-target-blank/src/example.html
+++ b/examples/external-links-target-blank/src/example.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>Example of making external links target _blank</title>
+  </head>
+  <body>
+    <a href="http://google.com">Google</a>
+    <a href="https://msn.com">Msn</a>
+    <a href="internal">Internal Link 1</a>
+    <a href="/internal">Internal Link 2</a>
+  </body>
+</html>


### PR DESCRIPTION
Hey -- great plugin thanks.

Here's an example mutator I wrote for making external links target _blank (open in a new window).