### PR TITLE
Updated gulp to version 3.9.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,11 +31,11 @@
     "vinyl-source-stream": "latest",
     "vinyl-buffer": "latest",
     "chai": "latest",
-    "gulp": "latest"
+    "gulp": "3.9.0"
   },
   "dependencies": {
     "jsdom": "6.5.x",
-    "gulp-util" : "3.0.x",
-    "through2" : "2.x"
+    "gulp-util": "3.0.x",
+    "through2": "2.x"
   }
 }


### PR DESCRIPTION
:rocket:

gulp just published version 3.9.0, so that’s now up to date in your `package.json`.

Check that it doesn’t break your code and release the new version of your software safe in the knowledge that it will stay in this working state.

---
This pull request was created by [greenkeeper.io](http://greenkeeper.io/).
It keeps your software, up to date, all the time.

<sub>
Tired of seeing this sponsor message? Upgrade to the supporter plan!
You'll also get your pull requests faster :zap:
</sub>