### PR TITLE
Remove need for second parameter by checking mutator return type

### DIFF
--- a/lib/dom.js
+++ b/lib/dom.js
@@ -11,7 +11,7 @@ var jsdom           = require("jsdom"),
 
 
 
-module.exports = function (mutator, serialize) {
+module.exports = function (mutator) {
     var stream = through2.obj(function(file, enc, callback) {
 
     if (file.isNull()) {
@@ -20,10 +20,6 @@ module.exports = function (mutator, serialize) {
 
     if (file.isStream()) {
         return stream.emit("error", new PluginError(pluginName, "Streaming not supported"));
-    }
-
-    if(serialize === undefined) {
-        serialize = true;
     }
 
     if (file.isBuffer()) {
@@ -37,7 +33,7 @@ module.exports = function (mutator, serialize) {
 
                     var mutated = mutator.call(window.document);
 
-                    file.contents = new Buffer(serialize ? jsdom.serializeDocument(mutated) : mutated);
+                    file.contents = new Buffer(typeof mutated === 'string' ? mutated : jsdom.serializeDocument(mutated));
                     callback(null, file);
 
                     window.close();


### PR DESCRIPTION
I feel it's redundant and a door for possible mistakes to have to rely on a parameter being set for something that can easily be checked programmatically.