### PR TITLE
Replaced the deprecated gulp-util dependency with suitable alternatives (plugin-error in production, and vinyl in test)

### DIFF
--- a/lib/dom.js
+++ b/lib/dom.js
@@ -5,7 +5,7 @@
 
 var jsdom           = require("jsdom"),
     utils           = require("gulp-util"),
-    PluginError     = utils.PluginError,
+    PluginError     = require('plugin-error'),
     through2        = require("through2"),
     pluginName      = "gulp-dom";
 

--- a/lib/dom.js
+++ b/lib/dom.js
@@ -4,7 +4,6 @@
 
 
 var jsdom           = require("jsdom"),
-    utils           = require("gulp-util"),
     PluginError     = require('plugin-error'),
     through2        = require("through2"),
     pluginName      = "gulp-dom";

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   },
   "dependencies": {
     "jsdom": "9.8.3",
-    "gulp-util": "3.0.8",
+    "plugin-error": "1.0.1",
     "through2": "2.0.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -31,7 +31,8 @@
     "vinyl-source-stream": "1.1.0",
     "vinyl-buffer": "1.0.0",
     "chai": "3.5.0",
-    "gulp": "3.9.1"
+    "gulp": "3.9.1",
+	"vinyl": "2.2.0"
   },
   "dependencies": {
     "jsdom": "9.8.3",

--- a/test/dom.js
+++ b/test/dom.js
@@ -5,14 +5,14 @@
 
 var mocha           = require('mocha'),
     assert          = require('chai').assert,
-    utils           = require('gulp-util'),
+    vinyl           = require('vinyl'),
     jsdom           = require('jsdom'),
     dom             = require('../');
 
 
 
 function createFixture(markup) {
-    return new utils.File({
+    return new Vinyl({
         cwd: './',
         base: './',
         path: './',

--- a/test/dom.js
+++ b/test/dom.js
@@ -5,7 +5,7 @@
 
 var mocha           = require('mocha'),
     assert          = require('chai').assert,
-    vinyl           = require('vinyl'),
+    Vinyl           = require('vinyl'),
     jsdom           = require('jsdom'),
     dom             = require('../');
 


### PR DESCRIPTION
…because that was the only 'util' being used from gulp-util

This is based on https://medium.com/gulpjs/gulp-util-ca3b1f9f9ac5